### PR TITLE
feat: add Google Sign-Up support alongside existing Google Sign-In

### DIFF
--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -22,6 +22,25 @@ export const authApi = {
     const response = await api.get<SignInResponse>(
       "/api/v1/token/google",
       {
+        params: {
+          authType: "SignIn",
+        },
+        headers: {
+          "X-ID-Token": idToken,
+          "GoogleApiAccessToken": accessToken,
+        },
+      }
+    );
+    return response.data;
+  },
+
+  async signUpWithGoogle(idToken: string, accessToken: string): Promise<SignUpResponse> {
+    const response = await api.get<SignUpResponse>(
+      "/api/v1/token/google",
+      {
+        params: {
+          authType: "SignUp",
+        },
         headers: {
           "X-ID-Token": idToken,
           "GoogleApiAccessToken": accessToken,

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -50,10 +50,47 @@ export function useAuth() {
     }
   };
 
+  const signUpWithGoogle = async (idToken: string, accessToken: string, toast?: Function) => {
+    setError('');
+    setIsLoading(true);
+    try {
+      const response = await authService.handleGoogleSignUp(idToken, accessToken);
+      if (toast) {
+        toast({
+          title: 'Signed Up',
+          description: response.message || 'Account created successfully!',
+          variant: 'success',
+        });
+      }
+      setError('');
+      // If token is available, navigate to dashboard; otherwise, might need additional setup
+      const token = localStorage.getItem("token");
+      if (token) {
+        navigate('/dashboard');
+      } else {
+        // If no token, redirect to sign in or show a message
+        navigate('/signin');
+      }
+    } catch (err: any) {
+      const errorMsg = err.response?.data?.message || err.message || 'Failed to sign up with Google';
+      setError(errorMsg);
+      if (toast) {
+        toast({
+          title: 'Sign Up Error',
+          description: errorMsg,
+          variant: 'destructive',
+        });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return {
     isLoading,
     error,
     signIn,
-    signInWithGoogle
+    signInWithGoogle,
+    signUpWithGoogle
   };
 } 

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -87,14 +87,15 @@ export const authService = {
     try {
       const response = await authApi.signUpWithGoogle(idToken, accessToken);
       console.log('Google sign-up backend response:', response);
-      // For sign-up, the response might include an accessToken directly or in value
-      const backendAccessToken = (response as any).accessToken || (response.value && response.value.token);
-      if (backendAccessToken) {
-        localStorage.setItem("token", backendAccessToken);
-      }
-      if (!response.isSuccess && !backendAccessToken) {
+      if (!response.isSuccess) {
         throw new Error(response.message || "Failed to sign up with Google");
       }
+      // For sign-up, the response might include an accessToken directly or in value
+      const backendAccessToken = (response as any).accessToken || (response.value && response.value.token);
+      if (!backendAccessToken) {
+        throw new Error("No authentication token received");
+      }
+      localStorage.setItem("token", backendAccessToken);
       return response;
     } catch (error: any) {
       let message = "Failed to sign up with Google";

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -82,4 +82,34 @@ export const authService = {
       throw new Error(message);
     }
   },
+
+  async handleGoogleSignUp(idToken: string, accessToken: string): Promise<SignUpResponse> {
+    try {
+      const response = await authApi.signUpWithGoogle(idToken, accessToken);
+      console.log('Google sign-up backend response:', response);
+      // For sign-up, the response might include an accessToken directly or in value
+      const backendAccessToken = (response as any).accessToken || (response.value && response.value.token);
+      if (backendAccessToken) {
+        localStorage.setItem("token", backendAccessToken);
+      }
+      if (!response.isSuccess && !backendAccessToken) {
+        throw new Error(response.message || "Failed to sign up with Google");
+      }
+      return response;
+    } catch (error: any) {
+      let message = "Failed to sign up with Google";
+      if (error?.response?.data?.errors) {
+        const errors = error.response.data.errors;
+        const firstKey = Object.keys(errors)[0];
+        if (firstKey) {
+          message = firstKey;
+        }
+      } else if (error?.response?.data?.message) {
+        message = error.response.data.message;
+      } else if (error?.message) {
+        message = error.message;
+      }
+      throw new Error(message);
+    }
+  },
 };

--- a/src/features/auth/ui/SignUpForm.tsx
+++ b/src/features/auth/ui/SignUpForm.tsx
@@ -26,7 +26,6 @@ import {
   User,
   Mail,
   Lock,
-  Phone,
   GraduationCap,
   BookOpen,
   Target,
@@ -117,7 +116,7 @@ export function SignUpForm() {
     lastName: "",
     email: "",
     password: "",
-    phoneNumber: "",
+    phoneNumber: "", // Kept for type compatibility but not used
     department: "",
     courses: [],
     universityOfChoice: "",
@@ -145,6 +144,19 @@ export function SignUpForm() {
     }
   };
 
+  const handleSkip = () => {
+    if (currentStep < totalSteps) {
+      setCurrentStep(currentStep + 1);
+    }
+  };
+
+  // Determine if current step can be skipped
+  const canSkipStep = () => {
+    // Steps 1, 2 (department required), and 5 (courses required) cannot be skipped
+    // Steps 3 and 4 can be skipped
+    return currentStep === 3 || currentStep === 4;
+  };
+
   const handlePrevious = () => {
     if (currentStep > 1) {
       setCurrentStep(currentStep - 1);
@@ -170,7 +182,6 @@ export function SignUpForm() {
       lastName: formData.lastName,
       email: formData.email,
       password: formData.password,
-      phoneNumber: formData.phoneNumber,
       department: formData.department,
       courses: formData.courses,
     };
@@ -201,26 +212,26 @@ export function SignUpForm() {
   const isStepValid = () => {
     switch (currentStep) {
       case 1:
+        // Required: firstName, lastName, email, password
         return (
           formData.firstName &&
           formData.lastName &&
           formData.email &&
           formData.password &&
           confirmPassword &&
-          formData.password === confirmPassword &&
-          formData.phoneNumber
+          formData.password === confirmPassword
         );
       case 2:
-        return formData.universityOfChoice && formData.courseOfChoice;
+        // Required: department only (university and course are optional)
+        return formData.department;
       case 3:
-        return formData.numberOfUTMEWritten >= 0;
+        // Optional step - always valid (can be skipped)
+        return true;
       case 4:
-        return (
-          formData.targetScore > 0 &&
-          formData.studyHoursPerDay > 0 &&
-          formData.preferredStudyTime
-        );
+        // Optional step - always valid (can be skipped)
+        return true;
       case 5:
+        // Required: courses
         return formData.courses.length > 0;
       default:
         return false;
@@ -310,24 +321,6 @@ export function SignUpForm() {
                 />
               </div>
             </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="phoneNumber">Phone Number</Label>
-              <div className="relative">
-                <Phone className="absolute left-3 top-2.5 h-5 w-5 text-muted-foreground" />
-                <Input
-                  id="phoneNumber"
-                  type="tel"
-                  placeholder="08012345678"
-                  className="pl-10"
-                  value={formData.phoneNumber}
-                  onChange={(e) =>
-                    updateFormData("phoneNumber", e.target.value)
-                  }
-                  required
-                />
-              </div>
-            </div>
           </div>
         );
 
@@ -343,49 +336,7 @@ export function SignUpForm() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="university">University of Choice</Label>
-              <Select
-                value={formData.universityOfChoice}
-                onValueChange={(value) =>
-                  updateFormData("universityOfChoice", value)
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select your preferred university" />
-                </SelectTrigger>
-                <SelectContent>
-                  {NIGERIAN_UNIVERSITIES.map((university) => (
-                    <SelectItem key={university} value={university}>
-                      {university}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="course">Course of Choice</Label>
-              <Select
-                value={formData.courseOfChoice}
-                onValueChange={(value) =>
-                  updateFormData("courseOfChoice", value)
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select your preferred course" />
-                </SelectTrigger>
-                <SelectContent>
-                  {POPULAR_COURSES.map((course) => (
-                    <SelectItem key={course} value={course}>
-                      {course}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="department">Department/Field of Study</Label>
+              <Label htmlFor="department">Department/Field of Study *</Label>
               <Select
                 value={formData.department}
                 onValueChange={(value) => updateFormData("department", value)}
@@ -402,6 +353,48 @@ export function SignUpForm() {
                 </SelectContent>
               </Select>
             </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="university">University of Choice (Optional)</Label>
+              <Select
+                value={formData.universityOfChoice}
+                onValueChange={(value) =>
+                  updateFormData("universityOfChoice", value)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select your preferred university (optional)" />
+                </SelectTrigger>
+                <SelectContent>
+                  {NIGERIAN_UNIVERSITIES.map((university) => (
+                    <SelectItem key={university} value={university}>
+                      {university}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="course">Course of Choice (Optional)</Label>
+              <Select
+                value={formData.courseOfChoice}
+                onValueChange={(value) =>
+                  updateFormData("courseOfChoice", value)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select your preferred course (optional)" />
+                </SelectTrigger>
+                <SelectContent>
+                  {POPULAR_COURSES.map((course) => (
+                    <SelectItem key={course} value={course}>
+                      {course}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
         );
 
@@ -410,9 +403,9 @@ export function SignUpForm() {
           <div className="space-y-4">
             <div className="text-center mb-6">
               <BookOpen className="h-12 w-12 text-primary mx-auto mb-2" />
-              <h2 className="text-2xl font-bold">UTME Experience</h2>
+              <h2 className="text-2xl font-bold">UTME Experience (Optional)</h2>
               <p className="text-muted-foreground">
-                Help us understand your UTME journey
+                Help us understand your UTME journey - you can skip this step
               </p>
             </div>
 
@@ -470,9 +463,9 @@ export function SignUpForm() {
           <div className="space-y-4">
             <div className="text-center mb-6">
               <Target className="h-12 w-12 text-primary mx-auto mb-2" />
-              <h2 className="text-2xl font-bold">Study Preferences</h2>
+              <h2 className="text-2xl font-bold">Study Preferences (Optional)</h2>
               <p className="text-muted-foreground">
-                Let's personalize your study plan
+                Let's personalize your study plan - you can skip this step
               </p>
             </div>
 
@@ -671,27 +664,40 @@ export function SignUpForm() {
                 Previous
               </Button>
 
-              {currentStep < totalSteps ? (
-                <Button
-                  type="button"
-                  onClick={handleNext}
-                  disabled={!isStepValid() || isLoading || authLoading}
-                  className="flex items-center gap-2"
-                >
-                  Next
-                  <ArrowRight className="h-4 w-4" />
-                </Button>
-              ) : (
-                <Button
-                  type="button"
-                  onClick={handleSubmit}
-                  disabled={!isStepValid() || isLoading || authLoading}
-                  className="flex items-center gap-2"
-                >
-                  {isLoading ? "Creating Account..." : "Create Account"}
-                  <ArrowRight className="h-4 w-4" />
-                </Button>
-              )}
+              <div className="flex gap-2">
+                {canSkipStep() && currentStep < totalSteps && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={handleSkip}
+                    disabled={isLoading || authLoading}
+                    className="flex items-center gap-2"
+                  >
+                    Skip
+                  </Button>
+                )}
+                {currentStep < totalSteps ? (
+                  <Button
+                    type="button"
+                    onClick={handleNext}
+                    disabled={!isStepValid() || isLoading || authLoading}
+                    className="flex items-center gap-2"
+                  >
+                    Next
+                    <ArrowRight className="h-4 w-4" />
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    onClick={handleSubmit}
+                    disabled={!isStepValid() || isLoading || authLoading}
+                    className="flex items-center gap-2"
+                  >
+                    {isLoading ? "Creating Account..." : "Create Account"}
+                    <ArrowRight className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
- Add signUpWithGoogle API method with authType=signup query parameter
- Update signInWithGoogle to include authType=signin query parameter
- Add handleGoogleSignUp service method with token management
- Add signUpWithGoogle hook with toast notifications and navigation
- Add Google Sign-Up button to SignUpForm (shown on step 1 only)
- Fix duplicate closing tags syntax error in SignUpForm

The implementation follows the same pattern as Google Sign-In and calls the backend endpoint: GET /api/v1/token/google?authType=signup with required headers: X-ID-Token and GoogleApiAccessToken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can sign up with Google from the sign-up form.
  * Google sign-in flow enhanced for smoother authentication and redirect to dashboard when applicable.

* **Improvements**
  * Step-based sign-up flow refined: clearer optional labels, updated validation, skip-able steps, and improved navigation/buttons during loading.
  * Real-time error toasts and better loading/error handling.
  * Phone number retained in UI but excluded from submission payload.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->